### PR TITLE
Fixed MC-72494: In Statistics screen 'm' is the same unit for both minutes and meters

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Astatine aims to fix those bugs in the most efficient ways, without compromising
 - ``MC-131562``: Pressing "Done" in an empty command block minecart returns "Command set:"
 - ``MC-72687``: Action Bar Messages do not have the small shadow under the text
 - ``MC-200000``: Merchant trade select packet (C2S) does not check for negative indices
+- ``MC-72494``: In Statistics screen 'm' is the same unit for both minutes and meters
 
 ### Bugs to be fixed
 

--- a/src/main/java/dev/dreamhopping/astatine/mixins/StatFormatterMixin.java
+++ b/src/main/java/dev/dreamhopping/astatine/mixins/StatFormatterMixin.java
@@ -1,0 +1,60 @@
+/*
+ *     Astatine is a mod for Minecraft which fixes many common bugs in the game
+ *     Copyright (C) 2021 Conor Byrne
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package dev.dreamhopping.astatine.mixins;
+
+import net.minecraft.stat.StatFormatter;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+import java.text.DecimalFormat;
+
+/**
+ * Fix MC-72494: In Statistics screen 'm' is the same unit for both minutes and meters
+ *
+ * @author UserTeemu with help of LlamaLad7
+ */
+@Mixin(StatFormatter.class)
+public interface StatFormatterMixin {
+    /**
+     * @author UserTeemu with help of LlamaLad7
+     */
+    @Overwrite
+    static String method_16819(int i) {
+        double d = (double)i / 20.0D;
+        double e = d / 60.0D;
+        double f = e / 60.0D;
+        double g = f / 24.0D;
+        double h = g / 365.0D;
+        if (h > 0.5D) {
+            return StatFormatter.DECIMAL_FORMAT.format(h) + " y";
+        } else if (g > 0.5D) {
+            return StatFormatter.DECIMAL_FORMAT.format(g) + " d";
+        } else if (f > 0.5D) {
+            return StatFormatter.DECIMAL_FORMAT.format(f) + " h";
+        } else {
+            return e > 0.5D ? StatFormatter.DECIMAL_FORMAT.format(e) + " min" : d + " s";
+        }
+    }
+}

--- a/src/main/resources/astatine.mixins.json
+++ b/src/main/resources/astatine.mixins.json
@@ -12,7 +12,8 @@
     "MerchantScreenMixin",
     "SeaPickleBlockMixin",
     "ServerPlayNetworkHandlerMixin",
-    "SquidEntityRendererMixin"
+    "SquidEntityRendererMixin",
+    "StatFormatterMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This is such a big and great change, that nobody can ever live without.
This change was so game breaking that only the best minecraft bug fixers could have done it. 

Removal of sarcasm and cringe in this text field is sold separately.